### PR TITLE
[members] do not revert before accounting_of_membership_fees_from

### DIFF
--- a/src/byro/members/models.py
+++ b/src/byro/members/models.py
@@ -496,6 +496,8 @@ class Member(Auditable, models.Model, LogTargetMixin):
             credit_account=src_account,
             transaction__reversed_by__isnull=True,
         )
+        if _from is not None:
+            dues_qs = dues_qs.filter(transaction__value_datetime__gte=_from)
         if membership_ranges:
             date_range_q = reduce(
                 lambda a, b: a | b,
@@ -551,6 +553,8 @@ class Member(Auditable, models.Model, LogTargetMixin):
             credit_account=src_account,
             transaction__reversed_by__isnull=True,
         )
+        if _from is not None:
+            stray_liabilities_qs = stray_liabilities_qs.filter(transaction__value_datetime__gte=_from)
         if membership_ranges:
             stray_liabilities_qs = stray_liabilities_qs.exclude(date_range_q)
         stray_liabilities_qs = stray_liabilities_qs.prefetch_related("transaction")


### PR DESCRIPTION
Before this commit, it was not possible to import a history of membership fee bookings from another tool (that was used before byro) into byro, because byro always tried to revert those old bookings.

Fixes 7a2cd5e50558482a7ac9c938951fc7134dad3f74